### PR TITLE
Remove Dyson 360 Heurist support

### DIFF
--- a/custom_components/dyson_cloud/camera.py
+++ b/custom_components/dyson_cloud/camera.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
     devices = data[DATA_DEVICES]
     entities = []
     for device in devices:
-        if device.product_type not in [DEVICE_TYPE_360_EYE, DEVICE_TYPE_360_HEURIST]:
+        if device.product_type not in [DEVICE_TYPE_360_EYE]:
             continue
         entities.append(DysonCleaningMapEntity(
             DysonCloud360Eye(account, device.serial),


### PR DESCRIPTION
The endpoints used for the Dyson 360 Eye do not work for the Heurist. There is support for cleaning history/maps at: https://appapi.cp.dyson.com/v1/{serial}/clean-maps but it appears to be a different format. When I have more time I can look into implementing camera support for the Heurist.

![04EA9BD1-357F-4592-929E-13A6C256FAFE_4_5005_c](https://user-images.githubusercontent.com/1022924/119186937-89723980-ba70-11eb-9255-7725659168cf.jpeg)
